### PR TITLE
Restore version2 generated build artifacts to version2 branch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ language:
 os:
     - osx
     - linux
-
+    
 compiler:
     - clang
     - gcc
-
+    
 env:
     - LINK=static
     - LINK=dynamic
@@ -68,8 +68,10 @@ install:
     - if [[ $LINUX && $GCC   && $STATIC  ]]; then sudo apt-get -qq install swig; fi
 
     # Download and install packages for osx/clang/dynamic.
-    - if [[ $OSX   && $CLANG && $DYNAMIC ]]; then brew unlink boost; brew install boost; fi
     - if [[ $OSX   && $CLANG && $DYNAMIC ]]; then brew unlink swig; brew install swig; fi
+
+    # Download and install packages for linux/clang/dynamic.
+    - if [[ $LINUX && $CLANG && $DYNAMIC ]]; then sudo apt-get -qq install boost1.54; fi
 
     # Download and install packages for linux/gcc/dynamic.
     - if [[ $LINUX && $GCC   && $DYNAMIC ]]; then sudo apt-get -qq install swig; fi
@@ -78,10 +80,10 @@ script:
 
     # Download and build libbitcoin-consensus and all dependencies.
     - if [[ $OSX   && $CLANG && $STATIC  ]]; then ./install.sh --with-java --disable-shared --build-boost --prefix=$TRAVIS_BUILD_DIR/my-prefix; fi
-    - if [[ $LINUX && $CLANG && $STATIC  ]]; then ./install.sh --with-python --disable-shared --build-boost --prefix=$TRAVIS_BUILD_DIR/my-prefix CFLAGS='-Os' CXXFLAGS='-Os'; fi
-    - if [[ $LINUX && $GCC   && $STATIC  ]]; then ./install.sh --with-java --disable-shared --build-boost --build-dir=my-build --prefix=$TRAVIS_BUILD_DIR/my-prefix CFLAGS='-O0 -g --coverage' CXXFLAGS='-O0 -g --coverage'; fi
+    - if [[ $LINUX && $CLANG && $STATIC  ]]; then ./install.sh --with-python --disable-shared --build-boost --prefix=$TRAVIS_BUILD_DIR/my-prefix CFLAGS='-Os' LDLIBS='-lstdc++' CXXFLAGS='-Os -stdlib=libstdc++'; fi
+    - if [[ $LINUX && $GCC   && $STATIC  ]]; then ./install.sh --with-java --disable-shared --build-boost --build-dir=my-build --prefix=$TRAVIS_BUILD_DIR/my-prefix CFLAGS='-O0 -g -static --coverage' CXXFLAGS='-O0 -g -static --coverage'; fi
     - if [[ $OSX   && $CLANG && $DYNAMIC ]]; then ./install.sh --with-python; fi
-    - if [[ $LINUX && $CLANG && $DYNAMIC ]]; then sudo CXX=$CXX CC=$CC ./install.sh --build-boost --disable-ndebug --disable-static CFLAGS='-Os' CXXFLAGS='-Os'; fi
+    - if [[ $LINUX && $CLANG && $DYNAMIC ]]; then sudo CXX=$CXX CC=$CC ./install.sh --disable-ndebug --disable-static CFLAGS='-Os' LDLIBS='-lstdc++' CXXFLAGS='-Os -stdlib=libstdc++'; fi
     - if [[ $LINUX && $GCC   && $DYNAMIC ]]; then sudo CXX=$CXX CC=$CC ./install.sh --with-java --with-python --disable-static --build-boost CFLAGS='-Os -s' CXXFLAGS='-Os -s'; fi
 
 after_success:
@@ -96,6 +98,6 @@ after_success:
     - if [[ $LINUX && $GCC   && $STATIC  ]]; then lcov --directory . --capture --output-file coverage.info; fi
     - if [[ $LINUX && $GCC   && $STATIC  ]]; then lcov --remove coverage.info "/usr/*" "$TRAVIS_BUILD_DIR/my-prefix/*" "my-build/*" "test/*" "clone/*" --output-file coverage.info; fi
     - if [[ $LINUX && $GCC   && $STATIC  ]]; then lcov --list coverage.info; fi
-
+    
     # Upload coverage info to coveralls service (--repo-token <private coveralls repo token>).
     - if [[ $LINUX && $GCC   && $STATIC  ]]; then coveralls-lcov coverage.info; fi

--- a/configure.ac
+++ b/configure.ac
@@ -7,9 +7,7 @@
 
 # Standard declarations.
 #==============================================================================
-# Requires Automake 1.14 or newer.
-
-# Declare the required version of Autoconf.
+# Declare the required version of autoconf.
 AC_PREREQ([2.65])
 
 # Process command-line arguments and perform initialization and verification.
@@ -353,15 +351,15 @@ AS_CASE([${CC}], [*gcc*],
          AC_MSG_NOTICE([boost_LDFLAGS : ${boost_LDFLAGS}])],
         [AC_MSG_ERROR([Boost 1.55.0 or later is required but was not found.])])])
 
-# Require Boost of at least version 1.56.0 if in clang and output ${boost_CPPFLAGS/LDFLAGS}.
+# Require Boost of at least version 1.54.0 if in clang and output ${boost_CPPFLAGS/LDFLAGS}.
 #------------------------------------------------------------------------------
 AS_CASE([${CC}], [*clang*],
-    [AX_BOOST_BASE([1.56.0],
+    [AX_BOOST_BASE([1.54.0],
         [AC_SUBST([boost_CPPFLAGS], [${BOOST_CPPFLAGS}])
          AC_SUBST([boost_LDFLAGS], [${BOOST_LDFLAGS}])
          AC_MSG_NOTICE([boost_CPPFLAGS : ${boost_CPPFLAGS}])
          AC_MSG_NOTICE([boost_LDFLAGS : ${boost_LDFLAGS}])],
-        [AC_MSG_ERROR([Boost 1.56.0 or later is required but was not found.])])])
+        [AC_MSG_ERROR([Boost 1.54.0 or later is required but was not found.])])])
 
 AS_CASE([${with_tests}], [yes],
     [AX_BOOST_UNIT_TEST_FRAMEWORK
@@ -426,6 +424,12 @@ AS_CASE([${CC}], [*],
 AS_CASE([${CC}], [*clang*],
     [AX_CHECK_COMPILE_FLAG([-Wno-mismatched-tags],
         [CXXFLAGS="$CXXFLAGS -Wno-mismatched-tags"])])
+
+# Clean up boost 1.54 headers. Enabled in clang only.
+#------------------------------------------------------------------------------
+AS_CASE([${CC}], [*clang*],
+    [AX_CHECK_COMPILE_FLAG([-Wno-deprecated-register],
+        [CXXFLAGS="$CXXFLAGS -Wno-deprecated-register"])])
 
 # Protect stack.
 #------------------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -24,16 +24,31 @@
 # Depending on the caller's permission to the --prefix or --build-dir
 # directory, the script may need to be sudo'd.
 
-# Define constants.
+# Define common constants.
 #==============================================================================
 # The default build directory.
 #------------------------------------------------------------------------------
 BUILD_DIR="build-libbitcoin-consensus"
 
-# Boost archive.
+# Boost archive for gcc.
 #------------------------------------------------------------------------------
-BOOST_URL="http://downloads.sourceforge.net/project/boost/boost/1.56.0/boost_1_56_0.tar.bz2"
-BOOST_ARCHIVE="boost_1_56_0.tar.bz2"
+BOOST_URL_GCC="http://github.com/libbitcoin/libbitcoin-build/blob/master/mirror/boost_1_55_0.tar.bz2?raw=true"
+BOOST_ARCHIVE_GCC="boost_1_55_0.tar.bz2"
+BOOST_STANDARD_GCC=\
+"threading=multi "\
+"variant=release "\
+"-d0 "\
+"-q"
+
+# Boost archive for clang.
+#------------------------------------------------------------------------------
+BOOST_URL_CLANG="http://github.com/libbitcoin/libbitcoin-build/blob/master/mirror/boost_1_54_0.tar.bz2?raw=true"
+BOOST_ARCHIVE_CLANG="boost_1_54_0.tar.bz2"
+BOOST_STANDARD_CLANG=\
+"threading=multi "\
+"variant=release "\
+"-d0 "\
+"-q"
 
 
 # Initialize the build environment.
@@ -58,27 +73,37 @@ else
     echo "Unsupported system: $OS"
     exit 1
 fi
+echo "Make jobs: $PARALLEL"
+echo "Make for system: $OS"
 
 # Define operating system specific settings.
 #------------------------------------------------------------------------------
 if [[ $OS == Darwin ]]; then
+    # Always require clang, common lib linking will otherwise fail.
     export CC="clang"
     export CXX="clang++"
-    STDLIB="c++"
+    LIBC="libc++"
+
+    # Always initialize prefix on OSX so default is useful.
+    PREFIX="/usr/local"
 elif [[ $OS == OpenBSD ]]; then
     make() { gmake "$@"; }
     export CC="egcc"
     export CXX="eg++"
-    STDLIB="estdc++"
-else # Linux
-    STDLIB="stdc++"
+    LIBC="libestdc++"
+else
+    LIBC="libstdc++"
 fi
+echo "Make with cc: $CC"
+echo "Make with cxx: $CXX"
+echo "Make with stdlib: $LIBC"
 
-# Link to appropriate standard library in non-default scnearios.
+# Define compiler specific settings.
 #------------------------------------------------------------------------------
-if [[ ($OS == Linux && $CC == "clang") || ($OS == OpenBSD) ]]; then
-    export LDLIBS="-l$STDLIB $LDLIBS"
-    export CXXFLAGS="-stdlib=lib$STDLIB $CXXFLAGS"
+COMPILER="GCC"
+if [[ $CXX == "clang++" ]]; then
+    BOOST_TOOLS="toolset=clang cxxflags=-stdlib=$LIBC linkflags=-stdlib=$LIBC"  
+    COMPILER="CLANG"
 fi
 
 # Parse command line options that are handled by this script.
@@ -87,137 +112,147 @@ for OPTION in "$@"; do
     case $OPTION in
         # Custom build options (in the form of --build-<option>).
         (--build-icu)      BUILD_ICU="yes";;
-        (--build-zlib)     BUILD_ZLIB="yes";;
-        (--build-png)      BUILD_PNG="yes";;
-        (--build-qrencode) BUILD_QRENCODE="yes";;
         (--build-boost)    BUILD_BOOST="yes";;
         (--build-dir=*)    BUILD_DIR="${OPTION#*=}";;
-
+        
         # Standard build options.
         (--prefix=*)       PREFIX="${OPTION#*=}";;
         (--disable-shared) DISABLE_SHARED="yes";;
         (--disable-static) DISABLE_STATIC="yes";;
         (--with-icu)       WITH_ICU="yes";;
-        (--with-png)       WITH_PNG="yes";;
-        (--with-qrencode)  WITH_QRENCODE="yes";;
     esac
 done
+echo "Build directory: $BUILD_DIR"
+echo "Prefix directory: $PREFIX"
 
-# Normalize of static and shared options.
+# Warn on configurations that imply static/prefix isolation.
 #------------------------------------------------------------------------------
-if [[ $DISABLE_SHARED ]]; then
-    CONFIGURE_OPTIONS=("$@" "--enable-static")
-elif [[ $DISABLE_STATIC ]]; then
-    CONFIGURE_OPTIONS=("$@" "--enable-shared")
-else
-    CONFIGURE_OPTIONS=("$@" "--enable-shared")
-    CONFIGURE_OPTIONS=("$@" "--enable-static")
+if [[ $BUILD_ICU == yes ]]; then
+    if [[ !($PREFIX)]]; then    
+        echo "Warning: --prefix recommended when building ICU."
+    fi
+    if [[ !($DISABLE_SHARED) ]]; then
+        echo "Warning: --disable-shared recommended when building ICU."
+    fi
+fi
+if [[ $BUILD_BOOST == yes ]]; then
+    if [[ !($PREFIX)]]; then    
+        echo "Warning: --prefix recommended when building boost."
+    fi
+    if [[ !($DISABLE_SHARED) ]]; then
+        echo "Warning: --disable-shared recommended when building boost."
+    fi
 fi
 
-# Purge custom build options so they don't break configure.
+# Purge custom options so they don't go to configure.
 #------------------------------------------------------------------------------
-CONFIGURE_OPTIONS=("${CONFIGURE_OPTIONS[@]/--build-*/}")
+CONFIGURE_OPTIONS=( "$@" )
+CUSTOM_OPTIONS=( "--build-icu" "--build-boost" "--build-dir=$BUILD_DIR" )
+for CUSTOM_OPTION in "${CUSTOM_OPTIONS[@]}"; do
+    CONFIGURE_OPTIONS=( "${CONFIGURE_OPTIONS[@]/$CUSTOM_OPTION}" )
+done
 
-# Always set a prefix (required on OSX and for lib detection).
+# Set link variables.
 #------------------------------------------------------------------------------
-if [[ !($PREFIX) ]]; then
-    PREFIX="/usr/local"
-    CONFIGURE_OPTIONS=( "${CONFIGURE_OPTIONS[@]}" "--prefix=$PREFIX")
+if [[ $DISABLE_STATIC == yes ]]; then
+    BOOST_LINK="link=shared"
+    ICU_LINK="--enable-shared --disable-static"
+elif [[ $DISABLE_SHARED == yes ]]; then
+    BOOST_LINK="link=static"
+    ICU_LINK="--disable-shared --enable-static"
 else
-    # Incorporate the custom libdir into each object, for runtime resolution.
-    export LD_RUN_PATH="$PREFIX/lib"
+    BOOST_LINK="link=static,shared"
+    ICU_LINK="--enable-shared --enable-static"
 fi
 
 # Incorporate the prefix.
 #------------------------------------------------------------------------------
-# Set the prefix-based package config directory.
-PREFIX_PKG_CONFIG_DIR="$PREFIX/lib/pkgconfig"
+if [[ $PREFIX ]]; then
+    # Set the prefix-based package config directory.
+    PREFIX_PKG_CONFIG_DIR="$PREFIX/lib/pkgconfig"
 
-# Augment PKG_CONFIG_PATH search path with our prefix.
-export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$PREFIX_PKG_CONFIG_DIR"
-
-# Set a package config save path that can be passed via our builds.
-with_pkgconfigdir="--with-pkgconfigdir=$PREFIX_PKG_CONFIG_DIR"
-
-if [[ $BUILD_BOOST ]]; then
-    # Boost has no pkg-config, m4 searches in the following order:
-    # --with-boost=<path>, /usr, /usr/local, /opt, /opt/local, $BOOST_ROOT.
-    # We use --with-boost to prioritize the --prefix path when we build it.
-    # Otherwise standard paths suffice for Linux, Homebrew and MacPorts.
-    # ax_boost_base.m4 appends /include and adds to BOOST_CPPFLAGS
-    # ax_boost_base.m4 searches for /lib /lib64 and adds to BOOST_LDFLAGS
-    with_boost="--with-boost=$PREFIX"
+    # Augment PKG_CONFIG_PATH search path with our prefix.
+    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$PREFIX_PKG_CONFIG_DIR"
+    
+    # Set public prefix variable.
+    prefix="--prefix=$PREFIX"
+    
+    # Set a package config save path that can be passed via our builds.
+    with_pkgconfigdir="--with-pkgconfigdir=$PREFIX_PKG_CONFIG_DIR"
+    
+    if [[ $BUILD_BOOST ]]; then
+        # Boost has no pkg-config, m4 searches in the following order:
+        # --with-boost=<path>, /usr, /usr/local, /opt, /opt/local, $BOOST_ROOT.
+        # We use --with-boost to prioritize the --prefix path when we build it.
+        # Otherwise standard paths suffice for Linux, Homebrew and MacPorts.
+        with_boost="--with-boost=$PREFIX" 
+    fi
 fi
 
-# Echo generated values.
+# Echo published dynamic build options.
 #------------------------------------------------------------------------------
-echo "Libbitcoin installer configuration."
-echo "--------------------------------------------------------------------"
-echo "OS                    : $OS"
-echo "PARALLEL              : $PARALLEL"
-echo "CC                    : $CC"
-echo "CXX                   : $CXX"
-echo "CPPFLAGS              : $CPPFLAGS"
-echo "CFLAGS                : $CFLAGS"
-echo "CXXFLAGS              : $CXXFLAGS"
-echo "LDFLAGS               : $LDFLAGS"
-echo "LDLIBS                : $LDLIBS"
-echo "WITH_ICU              : $WITH_ICU"
-echo "WITH_PNG              : $WITH_PNG"
-echo "WITH_QRENCODE         : $WITH_QRENCODE"
-echo "BUILD_ICU             : $BUILD_ICU"
-echo "BUILD_ZLIB            : $BUILD_ZLIB"
-echo "BUILD_PNG             : $BUILD_PNG"
-echo "BUILD_QRENCODE        : $BUILD_QRENCODE"
-echo "BUILD_BOOST           : $BUILD_BOOST"
-echo "PREFIX                : $PREFIX"
-echo "BUILD_DIR             : $BUILD_DIR"
-echo "DISABLE_SHARED        : $DISABLE_SHARED"
-echo "DISABLE_STATIC        : $DISABLE_STATIC"
-echo "with_boost            : ${with_boost}"
-echo "with_pkgconfigdir     : ${with_pkgconfigdir}"
-echo "--------------------------------------------------------------------"
+echo "  prefix: ${prefix}"
+echo "  with_boost: ${with_boost}"
+echo "  with_pkgconfigdir: ${with_pkgconfigdir}"
 
 
 # Define build options.
 #==============================================================================
-# Define boost options.
+# Define boost options for gcc.
 #------------------------------------------------------------------------------
-BOOST_OPTIONS=(
-"--with-system" \
-"--with-test")
+BOOST_OPTIONS_GCC=\
+"--with-system "\
+"--with-test "
+
+# Define boost options for clang.
+#------------------------------------------------------------------------------
+BOOST_OPTIONS_CLANG=\
+"--with-system "\
+"--with-test "
 
 # Define secp256k1 options.
 #------------------------------------------------------------------------------
-SECP256K1_OPTIONS=(
-"--disable-tests" \
-"--enable-module-recovery")
+SECP256K1_OPTIONS=\
+"--disable-tests "\
+"--enable-module-recovery "
 
 # Define bitcoin-consensus options.
 #------------------------------------------------------------------------------
-BITCOIN_CONSENSUS_OPTIONS=(
-"${with_boost}" \
-"${with_pkgconfigdir}")
+BITCOIN_CONSENSUS_OPTIONS=\
+"${with_boost} "\
+"${with_pkgconfigdir} "
 
 
 # Define utility functions.
 #==============================================================================
+circumvent_boost_icu_detection()
+{
+    # Boost expects a directory structure for ICU which is incorrect.
+    # Boost ICU discovery fails when using prefix, can't fix with -sICU_LINK,
+    # so we rewrite the two 'has_icu_test.cpp' files to always return success.
+    
+    if [[ $WITH_ICU ]]; then
+        local SUCCESS="int main() { return 0; }"
+        local REGEX_TEST="libs/regex/build/has_icu_test.cpp"
+        local LOCALE_TEST="libs/locale/build/has_icu_test.cpp"
+        
+        echo $SUCCESS > $REGEX_TEST
+        echo $SUCCESS > $LOCALE_TEST
+
+        echo "hack: ICU detection modified, will always indicate found."
+    fi
+}
+
 configure_options()
 {
-    echo "configure options:"
-    for OPTION in "$@"; do
-        if [[ $OPTION ]]; then
-            echo $OPTION
-        fi
-    done
-
+    echo "configure: $@"
     ./configure "$@"
 }
 
 configure_links()
 {
-    # Configure dynamic linker run-time bindings when installing to system.
-    if [[ ($OS == Linux) && ($PREFIX == "/usr/local") ]]; then
+    # Configure dynamic linker run-time bindings.
+    if [[ ($OS == Linux) && !($PREFIX) ]]; then
         ldconfig
     fi
 }
@@ -232,8 +267,7 @@ create_directory()
 
 display_message()
 {
-    local MESSAGE="$1"
-
+    MESSAGE="$1"
     echo
     echo "********************** $MESSAGE **********************"
     echo
@@ -246,7 +280,58 @@ initialize_git()
     git config user.name anonymous
 }
 
-# make_current_directory jobs [configure_options]
+initialize_boost_icu()
+{
+    if [[ $WITH_ICU ]]; then
+        # Restrict other local options when compiling boost with icu.
+        BOOST_ICU_ONLY="boost.locale.iconv=off boost.locale.posix=off"
+        
+        # Extract ICU prefix directory from package config variable.
+        local ICU_PREFIX=`pkg-config icu-i18n --variable=prefix`
+        BOOST_ICU_PATH="-sICU_PATH=$ICU_PREFIX"
+        BOOTSTRAP_WITH_ICU="--with-icu=$ICU_PREFIX"
+
+        # Extract ICU libs from package config variables and augment with -ldl.
+        local ICU_LIBS="`pkg-config icu-i18n --libs` -ldl"
+        BOOST_ICU_LINK="-sICU_LINK=$ICU_LIBS"
+    fi
+}
+
+initialize_icu_packages()
+{
+    if [[ ($OS == Darwin) && !($BUILD_ICU) ]]; then
+        # Update PKG_CONFIG_PATH for ICU package installations on OSX.
+        # OSX provides libicucore.dylib with no pkgconfig and doesn't support
+        # renaming or important features, so we can't use that.
+        HOMEBREW_ICU_PKG_CONFIG="/usr/local/opt/icu4c/lib/pkgconfig"
+        MACPORTS_ICU_PKG_CONFIG="/opt/local/lib/pkgconfig"
+        
+        if [[ -d "$HOMEBREW_ICU_PKG_CONFIG" ]]; then
+            export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$HOMEBREW_ICU_PKG_CONFIG"
+        elif [[ -d "$MACPORTS_ICU_PKG_CONFIG" ]]; then
+            export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$MACPORTS_ICU_PKG_CONFIG"
+        fi
+    fi
+}
+
+initialize_options()
+{
+    if [[ !($BOOST_OPTIONS) ]]; then
+        # Select compiler-conditional generated configuration parameters.
+        if [[ $COMPILER == CLANG ]]; then
+            BOOST_URL=$BOOST_URL_CLANG
+            BOOST_ARCHIVE=$BOOST_ARCHIVE_CLANG
+            BOOST_STANDARD=$BOOST_STANDARD_CLANG
+            BOOST_OPTIONS=$BOOST_OPTIONS_CLANG
+        else
+            BOOST_URL=$BOOST_URL_GCC
+            BOOST_ARCHIVE=$BOOST_ARCHIVE_GCC
+            BOOST_STANDARD=$BOOST_STANDARD_GCC
+            BOOST_OPTIONS=$BOOST_OPTIONS_GCC
+        fi
+    fi
+}
+
 make_current_directory()
 {
     local JOBS=$1
@@ -259,44 +344,35 @@ make_current_directory()
     configure_links
 }
 
-# make_jobs jobs [make_options]
 make_jobs()
 {
     local JOBS=$1
-    shift 1
+    local TARGET=$2
 
     # Avoid setting -j1 (causes problems on Travis).
     if [[ $JOBS > $SEQUENTIAL ]]; then
-        make -j$JOBS "$@"
+        make -j$JOBS $TARGET
     else
-        make "$@"
+        make $TARGET
     fi
 }
 
-# make_tests jobs
 make_tests()
 {
     local JOBS=$1
 
-    # Disable exit on error.
-    set +e
-
     # Build and run unit tests relative to the primary directory.
-    # VERBOSE=1 ensures test runner output sent to console (gcc).
-    make_jobs $JOBS check "VERBOSE=1"
-    local RESULT=$?
-
-    # Test runners emit to the test.log file.
-    if [[ -e "test.log" ]]; then
-        cat "test.log"
+    # VERBOSE=1 ensures test-suite.log output sent to console (gcc).
+    if ! make_jobs $JOBS check VERBOSE=1; then
+        if [ -e "test-suite.log" ]; then
+            echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+            echo "cat test-suite.log"
+            echo "------------------------------"
+            cat "test-suite.log"
+            echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+        fi
+        exit 1
     fi
-
-    if [[ $RESULT -ne 0 ]]; then
-        exit $RESULT
-    fi
-
-    # Reenable exit on error.
-    set -e
 }
 
 pop_directory()
@@ -307,333 +383,143 @@ pop_directory()
 push_directory()
 {
     local DIRECTORY="$1"
-
+    
     pushd "$DIRECTORY" >/dev/null
 }
 
 
-# Define build functions.
+# Build functions.
 #==============================================================================
-
-# Because PKG_CONFIG_PATH doesn't get updated by Homebrew or MacPorts.
-initialize_icu_packages()
-{
-    if [[ ($OS == Darwin) ]]; then
-        # Update PKG_CONFIG_PATH for ICU package installations on OSX.
-        # OSX provides libicucore.dylib with no pkgconfig and doesn't support
-        # renaming or important features, so we can't use that.
-        local HOMEBREW_ICU_PKG_CONFIG="/usr/local/opt/icu4c/lib/pkgconfig"
-        local MACPORTS_ICU_PKG_CONFIG="/opt/local/lib/pkgconfig"
-
-        if [[ -d "$HOMEBREW_ICU_PKG_CONFIG" ]]; then
-            export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$HOMEBREW_ICU_PKG_CONFIG"
-        elif [[ -d "$MACPORTS_ICU_PKG_CONFIG" ]]; then
-            export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$MACPORTS_ICU_PKG_CONFIG"
-        fi
-    fi
-}
-
-# Because ZLIB doesn't actually parse its --disable-shared option.
-# Because ZLIB doesn't follow GNU recommentation for unknown arguments.
-patch_zlib_configuration()
-{
-    sed -i.tmp "s/leave 1/shift/" configure
-    sed -i.tmp "s/--static/--static | --disable-shared/" configure
-    sed -i.tmp "/unknown option/d" configure
-    sed -i.tmp "/help for help/d" configure
-
-    # echo "Hack: ZLIB configuration options modified."
-}
-
-# Because ZLIB can't build shared only.
-clean_zlib_build()
-{
-    if [[ $DISABLE_STATIC ]]; then
-        rm --force "$PREFIX/lib/libz.a"
-    fi
-}
-
-# Standard build from tarball.
-build_from_tarball()
+build_from_tarball_icu()
 {
     local URL=$1
     local ARCHIVE=$2
-    local COMPRESSION=$3
-    local PUSH_DIR=$4
-    local JOBS=$5
-    local BUILD=$6
-    local OPTIONS=$7
-    shift 7
+    local REPO=$3
+    local JOBS=$4
+    shift 4
 
-    # For some platforms we need to set ICU pkg-config path.
-    if [[ !($BUILD) ]]; then
-        if [[ $ARCHIVE == $ICU_ARCHIVE ]]; then
-            initialize_icu_packages
-        fi
+    if [[ !($BUILD_ICU) ]]; then
+        initialize_icu_packages
+        display_message "ICU build not enabled"
         return
-    fi
-
-    # Because libpng doesn't actually use pkg-config to locate zlib.
-    # Because ICU tools don't know how to locate internal dependencies.
-    if [[ ($ARCHIVE == $ICU_ARCHIVE) || ($ARCHIVE == $PNG_ARCHIVE) ]]; then
-        local SAVE_LDFLAGS=$LDFLAGS
-        export LDFLAGS="-L$PREFIX/lib $LDFLAGS"
-    fi
-
-    # Because libpng doesn't actually use pkg-config to locate zlib.h.
-    if [[ ($ARCHIVE == $PNG_ARCHIVE) ]]; then
-        local SAVE_CPPFLAGS=$CPPFLAGS
-        export CPPFLAGS="-I$PREFIX/include $CPPFLAGS"
     fi
 
     display_message "Download $ARCHIVE"
 
-    # Use the suffixed archive name as the extraction directory.
-    local EXTRACT="build-$ARCHIVE"
-    create_directory $EXTRACT
-    push_directory $EXTRACT
+    create_directory $REPO
+    push_directory $REPO
 
     # Extract the source locally.
     wget --output-document $ARCHIVE $URL
-    tar --extract --file $ARCHIVE --$COMPRESSION --strip-components=1
-    push_directory $PUSH_DIR
+    tar --extract --file $ARCHIVE --strip-components=1
+    push_directory "source"
 
-    # Enable static only zlib build.
-    if [[ $ARCHIVE == $ZLIB_ARCHIVE ]]; then
-        patch_zlib_configuration
-    fi
-
-    # Join generated and command line options.
-    local CONFIGURATION=("${OPTIONS[@]}" "$@")
-
-    configure_options "${CONFIGURATION[@]}"
+    # Build and install.
+    # ICU is a typical GNU build except that it fails on unknown options.
+    configure_options $ICU_LINK $ICU_STANDARD ${prefix} "$@"
     make_jobs $JOBS --silent
     make install
     configure_links
 
-    # Enable shared only zlib build.
-    if [[ $ARCHIVE == $ZLIB_ARCHIVE ]]; then
-        clean_zlib_build
-    fi
-
     pop_directory
     pop_directory
-
-    # Restore flags to prevent side effects.
-    export LDFLAGS=$SAVE_LDFLAGS
-    export CPPFLAGS=$SAVE_LCPPFLAGS
 }
 
-# Because boost ICU detection assumes in incorrect ICU path.
-circumvent_boost_icu_detection()
-{
-    # Boost expects a directory structure for ICU which is incorrect.
-    # Boost ICU discovery fails when using prefix, can't fix with -sICU_LINK,
-    # so we rewrite the two 'has_icu_test.cpp' files to always return success.
-
-    local SUCCESS="int main() { return 0; }"
-    local REGEX_TEST="libs/regex/build/has_icu_test.cpp"
-    local LOCALE_TEST="libs/locale/build/has_icu_test.cpp"
-
-    echo $SUCCESS > $REGEX_TEST
-    echo $SUCCESS > $LOCALE_TEST
-
-    # echo "Hack: ICU detection modified, will always indicate found."
-}
-
-# Because boost doesn't support autoconfig and doesn't like empty settings.
-initialize_boost_configuration()
-{
-    if [[ $DISABLE_STATIC ]]; then
-        BOOST_LINK="shared"
-    elif [[ $DISABLE_SHARED ]]; then
-        BOOST_LINK="static"
-    else
-        BOOST_LINK="static,shared"
-    fi
-
-    if [[ $CC ]]; then
-        BOOST_TOOLSET="toolset=$CC"
-    fi
-
-    if [[ ($OS == Linux && $CC == "clang") || ($OS == OpenBSD) ]]; then
-        STDLIB_FLAG="-stdlib=lib$STDLIB"
-        BOOST_CXXFLAGS="cxxflags=$STDLIB_FLAG"
-        BOOST_LINKFLAGS="linkflags=$STDLIB_FLAG"
-    fi
-}
-
-# Because boost doesn't use pkg-config.
-initialize_boost_icu_configuration()
-{
-    BOOST_ICU_ICONV="on"
-    BOOST_ICU_POSIX="on"
-
-    if [[ $WITH_ICU ]]; then
-        circumvent_boost_icu_detection
-
-        # Restrict other locale options when compiling boost with icu.
-        BOOST_ICU_ICONV="off"
-        BOOST_ICU_POSIX="off"
-
-        # Extract ICU libs from package config variables and augment with -ldl.
-        ICU_LIBS=( `pkg-config icu-i18n --libs` "-ldl" )
-
-        # This is a hack for boost m4 scripts that fail with ICU dependency.
-        # See custom edits in ax-boost-locale.m4 and ax_boost_regex.m4.
-        export BOOST_ICU_LIBS="${ICU_LIBS[@]}"
-
-        # Extract ICU prefix directory from package config variable.
-        ICU_PREFIX=`pkg-config icu-i18n --variable=prefix`
-    fi
-}
-
-# Because boost doesn't use autoconfig.
 build_from_tarball_boost()
 {
     local URL=$1
     local ARCHIVE=$2
-    local COMPRESSION=$3
-    local PUSH_DIR=$4
-    local JOBS=$5
-    local BUILD=$6
-    shift 6
+    local REPO=$3
+    local JOBS=$4
+    shift 4
 
-    if [[ !($BUILD) ]]; then
+    if [[ !($BUILD_BOOST) ]]; then
+        display_message "Boost build not enabled"
         return
     fi
-
+    
     display_message "Download $ARCHIVE"
 
-    # Use the suffixed archive name as the extraction directory.
-    local EXTRACT="build-$ARCHIVE"
-    create_directory $EXTRACT
-    push_directory $EXTRACT
+    create_directory $REPO
+    push_directory $REPO
 
     # Extract the source locally.
     wget --output-document $ARCHIVE $URL
-    tar --extract --file $ARCHIVE --$COMPRESSION --strip-components=1
+    tar --extract --file $ARCHIVE --bzip2 --strip-components=1
+    
+    # Circumvent Boost ICU detection bug.
+    circumvent_boost_icu_detection
 
-    initialize_boost_configuration
-    initialize_boost_icu_configuration
-
-    echo "Libbitcoin boost configuration."
-    echo "--------------------------------------------------------------------"
-    echo "variant               : release"
-    echo "threading             : multi"
-    echo "toolset               : $CC"
-    echo "cxxflags              : $STDLIB_FLAG"
-    echo "linkflags             : $STDLIB_FLAG"
-    echo "link                  : $BOOST_LINK"
-    echo "boost.locale.iconv    : $BOOST_ICU_ICONV"
-    echo "boost.locale.posix    : $BOOST_ICU_POSIX"
-    echo "-sNO_BZIP2            : 1" 
-    echo "-sICU_PATH            : $ICU_PREFIX"
-    echo "-sICU_LINK            : ${ICU_LIBS[@]}"
-    echo "-sZLIB_LIBPATH        : $PREFIX/lib"
-    echo "-sZLIB_INCLUDE        : $PREFIX/include"
-    echo "-j                    : $JOBS"
-    echo "-d0                   : [supress informational messages]"
-    echo "-q                    : [stop at the first error]"
-    echo "--reconfigure         : [ignore cached configuration]"
-    echo "--prefix              : $PREFIX"
-    echo "BOOST_OPTIONS         : $@"
-    echo "--------------------------------------------------------------------"
-
-    # boost_iostreams
-    # The zlib options prevent boost linkage to system libs in the case where
-    # we have built zlib in a prefix dir. Disabling zlib in boost is broken in
-    # all versions (through 1.60). https://svn.boost.org/trac/boost/ticket/9156
-    # The bzip2 auto-detection is not implemented, but disabling it works.
-
-    ./bootstrap.sh \
-        "--prefix=$PREFIX" \
-        "--with-icu=$ICU_PREFIX"
-
-    ./b2 install \
-        "variant=release" \
-        "threading=multi" \
-        "$BOOST_TOOLSET" \
-        "$BOOST_CXXFLAGS" \
-        "$BOOST_LINKFLAGS" \
-        "link=$BOOST_LINK" \
-        "boost.locale.iconv=$BOOST_ICU_ICONV" \
-        "boost.locale.posix=$BOOST_ICU_POSIX" \
-        "-sNO_BZIP2=1" \
-        "-sICU_PATH=$ICU_PREFIX" \
-        "-sICU_LINK=${ICU_LIBS[@]}" \
-        "-sZLIB_LIBPATH=$PREFIX/lib" \
-        "-sZLIB_INCLUDE=$PREFIX/include" \
-        "-j $JOBS" \
-        "-d0" \
-        "-q" \
-        "--reconfigure" \
-        "--prefix=$PREFIX" \
-        "$@"
+    initialize_boost_icu
+    
+    # Build and install.
+    BOOSTSTRAP_OPTIONS="${prefix} $BOOTSTRAP_WITH_ICU"
+    B2_OPTIONS="install --reconfigure -j $JOBS ${prefix} $BOOST_LINK $BOOST_TOOLS $BOOST_STANDARD $BOOST_ICU_PATH $BOOST_ICU_LINK $BOOST_ICU_ONLY $@"
+    
+    echo "bootstrap: $BOOSTSTRAP_OPTIONS"
+    echo "b2: $B2_OPTIONS"
+    echo
+    
+    ./bootstrap.sh $BOOSTSTRAP_OPTIONS
+    ./b2 $B2_OPTIONS
+    
+    # Boost has no pkg-config, m4 searches in the following order:
+    # --with-boost=<path>, /usr, /usr/local, /opt, /opt/local, $BOOST_ROOT.
+    # We use --with-boost to prioritize the --prefix path when we build it.
+    # Otherwise standard paths suffice for Linux, Homebrew and MacPorts.
+    with_boost="--with-boost=$PREFIX"
 
     pop_directory
 }
 
-# Standard build from github.
 build_from_github()
 {
     local ACCOUNT=$1
     local REPO=$2
     local BRANCH=$3
     local JOBS=$4
-    local OPTIONS=$5
-    shift 5
+    shift 4
 
     FORK="$ACCOUNT/$REPO"
     display_message "Download $FORK/$BRANCH"
-
+    
     # Clone the repository locally.
     git clone --branch $BRANCH --single-branch "https://github.com/$FORK"
 
-    # Join generated and command line options.
-    local CONFIGURATION=("${OPTIONS[@]}" "$@")
-
     # Build the local repository clone.
     push_directory $REPO
-    make_current_directory $JOBS "${CONFIGURATION[@]}"
+    make_current_directory $JOBS "$@"
     pop_directory
 }
 
-# Standard build of current directory.
 build_from_local()
 {
     local MESSAGE="$1"
     local JOBS=$2
-    local OPTIONS=$3
-    shift 3
+    shift 2
 
     display_message "$MESSAGE"
 
-    # Join generated and command line options.
-    local CONFIGURATION=("${OPTIONS[@]}" "$@")
-
     # Build the current directory.
-    make_current_directory $JOBS "${CONFIGURATION[@]}"
+    make_current_directory $JOBS "$@"
 }
 
-# Because Travis alread has downloaded the primary repo.
 build_from_travis()
 {
     local ACCOUNT=$1
     local REPO=$2
     local BRANCH=$3
     local JOBS=$4
-    local OPTIONS=$5
-    shift 5
+    shift 4
 
     # The primary build is not downloaded if we are running in Travis.
     if [[ $TRAVIS == true ]]; then
         push_directory ".."
-        build_from_local "Local $TRAVIS_REPO_SLUG" $JOBS "${OPTIONS[@]}" "$@"
+        build_from_local "Local $TRAVIS_REPO_SLUG" $JOBS "$@"
         make_tests $JOBS
         pop_directory
     else
-        build_from_github $ACCOUNT $REPO $BRANCH $JOBS "${OPTIONS[@]}" "$@"
+        build_from_github $ACCOUNT $REPO $BRANCH $JOBS "$@"
         push_directory $REPO
         make_tests $JOBS
         pop_directory
@@ -645,9 +531,9 @@ build_from_travis()
 #==============================================================================
 build_all()
 {
-    build_from_tarball_boost $BOOST_URL    $BOOST_ARCHIVE    bzip2 .      $PARALLEL  "$BUILD_BOOST"    "${BOOST_OPTIONS[@]}"
-    build_from_github libbitcoin secp256k1 version4 $PARALLEL ${SECP256K1_OPTIONS[@]} "$@"
-    build_from_travis libbitcoin libbitcoin-consensus version2 $PARALLEL ${BITCOIN_CONSENSUS_OPTIONS[@]} "$@"
+    build_from_tarball_boost $BOOST_URL $BOOST_ARCHIVE boost $PARALLEL $BOOST_OPTIONS
+    build_from_github libbitcoin secp256k1 version4 $PARALLEL "$@" $SECP256K1_OPTIONS
+    build_from_travis libbitcoin libbitcoin-consensus version2 $PARALLEL "$@" $BITCOIN_CONSENSUS_OPTIONS
 }
 
 
@@ -656,5 +542,6 @@ build_all()
 create_directory "$BUILD_DIR"
 push_directory "$BUILD_DIR"
 initialize_git
+initialize_options
 time build_all "${CONFIGURE_OPTIONS[@]}"
 pop_directory

--- a/libbitcoin_consensus_test_runner.sh
+++ b/libbitcoin_consensus_test_runner.sh
@@ -18,4 +18,4 @@ BOOST_UNIT_TEST_OPTIONS=\
 
 # Run tests.
 #==============================================================================
-./test/libbitcoin_consensus_test ${BOOST_UNIT_TEST_OPTIONS} > test.log
+./test/libbitcoin_consensus_test ${BOOST_UNIT_TEST_OPTIONS}


### PR DESCRIPTION
The boost version should not have been bumped for the version2 branch, this rolls it back.
